### PR TITLE
FDBCORE-617: Add mako option to prepend padding

### DIFF
--- a/bindings/c/test/mako/mako.c
+++ b/bindings/c/test/mako/mako.c
@@ -151,18 +151,46 @@ void* fdb_network_thread(void* args) {
 	return 0;
 }
 
+int genprefix(char* str, char* prefix, int prefixlen, int prefixpadding, int rows, int len) {
+        const int rowdigit = digits(rows);
+        const int paddinglen = len - (prefixlen + rowdigit) - 1;
+        int offset = 0;
+        if (prefixpadding) {
+                memset(str, 'x', paddinglen);
+                offset += paddinglen;
+        }
+        memcpy(str + offset, prefix, prefixlen);
+        str[len - 1] = '\0';
+        return offset + prefixlen;
+}
+
+
 /* cleanup database */
 int cleanup(FDBTransaction* transaction, mako_args_t* args) {
 	struct timespec timer_start, timer_end;
-	char beginstr[7];
-	char endstr[7];
+	char* prefixstr = (char*)malloc(sizeof(char) * args->key_length + 1);
+	if (!prefixstr)
+		return -1;
+	char* beginstr = (char*)malloc(sizeof(char) * args->key_length + 1);
+	if (!beginstr) {
+		free(prefixstr);
+		return -1;
+	}
+	char* endstr = (char*)malloc(sizeof(char) * args->key_length + 1);
+	if (!endstr) {
+		free(prefixstr);
+		free(beginstr);
+		return -1;
+	}
 
-	strncpy(beginstr, "mako", 4);
-	beginstr[4] = 0x00;
-	strncpy(endstr, "mako", 4);
-	endstr[4] = 0xff;
+	int len = genprefix(prefixstr, KEYPREFIX, KEYPREFIXLEN, args->prefixpadding, args->rows, args->key_length + 1);
+	snprintf(beginstr, len + 2, "%s%c", prefixstr, 0x00);
+	snprintf(endstr, len + 2, "%s%c", prefixstr, 0xff);
+	free(prefixstr);
+	len += 1;
+
 	clock_gettime(CLOCK_MONOTONIC_COARSE, &timer_start);
-	fdb_transaction_clear_range(transaction, (uint8_t*)beginstr, 5, (uint8_t*)endstr, 5);
+	fdb_transaction_clear_range(transaction, (uint8_t*)beginstr, len + 1, (uint8_t*)endstr, len + 1);
 	if (commit_transaction(transaction) != FDB_SUCCESS)
 		goto failExit;
 
@@ -172,9 +200,16 @@ int cleanup(FDBTransaction* transaction, mako_args_t* args) {
 	        "INFO: Clear range: %6.3f sec\n",
 	        ((timer_end.tv_sec - timer_start.tv_sec) * 1000000000.0 + timer_end.tv_nsec - timer_start.tv_nsec) /
 	            1000000000);
+
+	free(beginstr);
+	free(endstr);
+
 	return 0;
 
 failExit:
+	free(beginstr);
+	free(endstr);
+
 	fprintf(stderr, "ERROR: FDB failure in cleanup()\n");
 	return -1;
 }
@@ -220,7 +255,7 @@ int populate(FDBTransaction* transaction,
 	for (i = begin; i <= end; i++) {
 
 		/* sequential keys */
-		genkey(keystr, i, args->rows, args->key_length + 1);
+		genkey(keystr, KEYPREFIX, KEYPREFIXLEN, args->prefixpadding, i, args->rows, args->key_length + 1);
 		/* random values */
 		randstr(valstr, args->value_length + 1);
 
@@ -512,7 +547,7 @@ retryTxn:
 				} else {
 					keynum = urand(0, args->rows - 1);
 				}
-				genkey(keystr, keynum, args->rows, args->key_length + 1);
+				genkey(keystr, KEYPREFIX, KEYPREFIXLEN, args->prefixpadding, keynum, args->rows, args->key_length + 1);
 
 				/* range */
 				if (args->txnspec.ops[i][OP_RANGE] > 0) {
@@ -520,7 +555,7 @@ retryTxn:
 					if (keyend > args->rows - 1) {
 						keyend = args->rows - 1;
 					}
-					genkey(keystr2, keyend, args->rows, args->key_length + 1);
+				  genkey(keystr2, KEYPREFIX, KEYPREFIXLEN, args->prefixpadding, keyend, args->rows, args->key_length + 1);
 				}
 
 				if (stats->xacts % args->sampling == 0) {
@@ -1354,6 +1389,7 @@ int init_args(mako_args_t* args) {
 	args->flatbuffers = 0; /* internal */
 	args->knobs[0] = '\0';
 	args->log_group[0] = '\0';
+	args->prefixpadding = 0;
 	args->trace = 0;
 	args->tracepath[0] = '\0';
 	args->traceformat = 0; /* default to client's default (XML) */
@@ -1515,6 +1551,7 @@ void usage() {
 	printf("%-24s %s\n", "-z, --zipf", "Use zipfian distribution instead of uniform distribution");
 	printf("%-24s %s\n", "    --commitget", "Commit GETs");
 	printf("%-24s %s\n", "    --loggroup=LOGGROUP", "Set client log group");
+	printf("%-24s %s\n", "    --prefix_padding", "Pad key by prefixing data (Default: postfix padding)");
 	printf("%-24s %s\n", "    --trace", "Enable tracing");
 	printf("%-24s %s\n", "    --tracepath=PATH", "Set trace file path");
 	printf("%-24s %s\n", "    --trace_format <xml|json>", "Set trace format (Default: json)");
@@ -1567,6 +1604,7 @@ int parse_args(int argc, char* argv[], mako_args_t* args) {
 			                                    { "zipf", no_argument, NULL, 'z' },
 			                                    { "commitget", no_argument, NULL, ARG_COMMITGET },
 			                                    { "flatbuffers", no_argument, NULL, ARG_FLATBUFFERS },
+			                                    { "prefix_padding", no_argument, NULL, ARG_PREFIXPADDING },
 			                                    { "trace", no_argument, NULL, ARG_TRACE },
 			                                    { "txntagging", required_argument, NULL, ARG_TXNTAGGING },
 			                                    { "txntagging_prefix", required_argument, NULL, ARG_TXNTAGGINGPREFIX },
@@ -1669,6 +1707,9 @@ int parse_args(int argc, char* argv[], mako_args_t* args) {
 			break;
 		case ARG_LOGGROUP:
 			memcpy(args->log_group, optarg, strlen(optarg) + 1);
+			break;
+		case ARG_PREFIXPADDING:
+			args->prefixpadding = 1;
 			break;
 		case ARG_TRACE:
 			args->trace = 1;

--- a/bindings/c/test/mako/mako.h
+++ b/bindings/c/test/mako/mako.h
@@ -69,6 +69,7 @@ enum Arguments {
 	ARG_KNOBS,
 	ARG_FLATBUFFERS,
 	ARG_LOGGROUP,
+	ARG_PREFIXPADDING,
 	ARG_TRACE,
 	ARG_TRACEPATH,
 	ARG_TRACEFORMAT,
@@ -125,6 +126,7 @@ typedef struct {
 	mako_txnspec_t txnspec;
 	char cluster_file[PATH_MAX];
 	char log_group[LOGGROUP_MAX];
+	int prefixpadding;
 	int trace;
 	char tracepath[PATH_MAX];
 	int traceformat; /* 0 - XML, 1 - JSON */

--- a/bindings/c/test/mako/utils.c
+++ b/bindings/c/test/mako/utils.c
@@ -3,6 +3,7 @@
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 /* uniform-distribution random */
 int urand(int low, int high) {
@@ -67,15 +68,17 @@ int digits(int num) {
 }
 
 /* generate a key for a given key number */
+/* prefix is "mako" by default, prefixpadding = 1 means 'x' will be in front rather than trailing the keyname */
 /* len is the buffer size, key length + null */
-void genkey(char* str, int num, int rows, int len) {
-	int i;
-	int rowdigit = digits(rows);
-	sprintf(str, KEYPREFIX "%0.*d", rowdigit, num);
-	for (i = (KEYPREFIXLEN + rowdigit); i < len - 1; i++) {
-		str[i] = 'x';
-	}
-	str[len - 1] = '\0';
+void genkey(char* str, char* prefix, int prefixlen, int prefixpadding, int num, int rows, int len) {
+        const int rowdigit = digits(rows);
+        const int prefixoffset = prefixpadding ? len - (prefixlen + rowdigit) - 1 : 0;
+        char* prefixstr = (char*)malloc(sizeof(char) * (prefixlen + rowdigit + 1));
+        snprintf(prefixstr, prefixlen + rowdigit + 1, "%s%0.*d", prefix, rowdigit, num);
+        memset(str, 'x', len);
+        memcpy(str + prefixoffset, prefixstr, prefixlen + rowdigit);
+        str[len - 1] = '\0';
+        free(prefixstr);
 }
 
 /* This is another sorting algorithm used to calculate latency parameters */

--- a/bindings/c/test/mako/utils.h
+++ b/bindings/c/test/mako/utils.h
@@ -47,8 +47,9 @@ int compute_thread_portion(int val, int p_idx, int t_idx, int total_p, int total
 int digits(int num);
 
 /* generate a key for a given key number */
+/* prefix is "mako" by default, prefixpadding = 1 means 'x' will be in front rather than trailing the keyname */
 /* len is the buffer size, key length + null */
-void genkey(char* str, int num, int rows, int len);
+void genkey(char* str, char* prefix, int prefixlen, int prefixpadding, int num, int rows, int len);
 
 #if 0
 // The main function is to sort arr[] of size n using Radix Sort


### PR DESCRIPTION
Cherry-pick prepend-padding mako option

## General guideline:

- If this PR is ready to be merged (and all checkboxes below are either ticked or not applicable), make this a regular PR
- If this PR still needs work, please make this a draft PR
  - If you wish to get feedback/code-review, please add the label RFC to this PR

Please verify that all things listed below were considered and check them. If an item doesn't apply to this type of PR (for example a documentation change doesn't need to be performance tested), you should make a ~~strikethrough~~ (markdown syntax: `~~strikethrough~~`). More infos on the guidlines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

### Style

- [ ] All variable and function names make sense.
- [ ] The code is properly formatted (consider running `git clang-format`).

### Performance

- [ ] All CPU-hot paths are well optimized.
- [ ] The proper containers are used (for example `std::vector` vs `VectorRef`).
- [ ] There are no new known `SlowTask` traces.

### Testing

- [ ] The code was sufficiently tested in simulation.
- [ ] If there are new parameters or knobs, different values are tested in simulation.
- [ ] `ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.
- [ ] Unit tests were added for new algorithms and data structure that make sense to unit-test
- [ ] If this is a bugfix: there is a test that can easily reproduce the bug.
